### PR TITLE
Adds write-only support for increased security. Skips faux 'lost+found' db that breaks script.

### DIFF
--- a/settings-sample.rb
+++ b/settings-sample.rb
@@ -17,6 +17,15 @@ TMP_BACKUP_PATH = '/tmp' # Will be created as parent for a temp directory before
 # use SSL to transmit backups to S3 (a good idea)
 USE_SSL = true
 
+# LIMIT PRIVILEGES
+#  * Limits actions to only write new backups and create new buckets. No attempts are made to
+#    delete data from S3. Set this to true when the credentials you provide don't have the
+#    rights to perform deletions. This is a handy way to prevent disaster should someone
+#    malicious gain access to them. With correctly restricted IAM permissions they won't be
+#    able to delete existing backups. Use a separate server and credentials to purge old backups.
+#    (default is false)
+SKIP_DELETE = false
+
 # CREATE AWS/S3 CONNECTION
 AWS::S3::Base.establish_connection!(
   :access_key_id  => '*** YOUR CREDENTIALS HERE ***',

--- a/simple-s3-backup.rb
+++ b/simple-s3-backup.rb
@@ -108,8 +108,10 @@ end
 # Remove tmp directory
 FileUtils.remove_dir full_tmp_path
 
-# Now, clean up unwanted archives
-cutoff_date = Time.now.utc.to_i - (DAYS_OF_ARCHIVES * 86400)
-bucket.objects.select{ |o| o.last_modified.to_i < cutoff_date }.each do |f|
-  S3Object.delete(f.key, S3_BUCKET)
+# Now, clean up unwanted archives, if allowed
+unless SKIP_DELETE
+  cutoff_date = Time.now.utc.to_i - (DAYS_OF_ARCHIVES * 86400)
+  bucket.objects.select{ |o| o.last_modified.to_i < cutoff_date }.each do |f|
+    S3Object.delete(f.key, S3_BUCKET)
+  end
 end

--- a/simple-s3-backup.rb
+++ b/simple-s3-backup.rb
@@ -36,6 +36,7 @@ if defined?(MYSQL_ALL or MYSQL_DBS)
     connection = Sequel.mysql nil, :user => MYSQL_USER, :password => MYSQL_PASS, :host => 'localhost', :encoding => 'utf8'
     @databases = connection['show databases;'].collect { |db| db[:Database] }
     @databases.delete("performance_schema") # Remove this db from the list, since it makes no sense to back up and causes some errors with --events.
+    @databases.delete("#mysql50#lost+found") # Skip this db since backup would fail. Not a real db but artifact of putting the MySQL datadir on own volume with ext3/4 fs.
   elsif defined?(MYSQL_DBS)
     @databases = MYSQL_DBS
   end


### PR DESCRIPTION
Adds write-only support to allow for stricter S3 IAM privileges. The IAM credentials used with the script may not have the privileges to delete objects from S3 buckets, in order to impede an attacker on a compromised host from simply deleting backup objects. Unfortunately S3 allows overwriting of objects via the same PutObject privilege so this is just an extra hurdle. If you can write you can overwrite, just not delete, so enable bucket versioning as well. Also you need some other script with other credentials (on some other host) to rotate the old backups, or you need to set up lifecycle-management rules on the bucket.

Skips faux 'lost+found' db, which can break the script. If MySQL's datadir is on a separate volume with an ext3/ext4 filesystem MySQL will assume the mandatory lost+found directory is a database, which it obviously is not. When the script tries to mysqldump this db it breaks, eventually filling /tmp with incomplete dumps. A simple solution is to not try to backup this 'db' at all.
